### PR TITLE
feat: allow pass flag/modifires in regexp pattern

### DIFF
--- a/src/conditions/creatorMatches.ts
+++ b/src/conditions/creatorMatches.ts
@@ -12,7 +12,7 @@ const creatorMatches = (
   condition: ConditionCreatorMatches,
   issue: IssueProps | PRProps,
 ) => {
-  const pattern = new RegExp(processRegExpPattern(condition.pattern));
+  const pattern = processRegExpPattern(condition.pattern);
   return pattern.test(issue.creator);
 };
 

--- a/src/conditions/creatorMatches.ts
+++ b/src/conditions/creatorMatches.ts
@@ -1,4 +1,5 @@
 import { IssueProps, PRProps } from '.';
+import { processRegExpPattern } from '../utils';
 
 const TYPE = 'creatorMatches';
 
@@ -11,7 +12,7 @@ const creatorMatches = (
   condition: ConditionCreatorMatches,
   issue: IssueProps | PRProps,
 ) => {
-  const pattern = new RegExp(condition.pattern);
+  const pattern = new RegExp(processRegExpPattern(condition.pattern));
   return pattern.test(issue.creator);
 };
 

--- a/src/conditions/descriptionMatches.ts
+++ b/src/conditions/descriptionMatches.ts
@@ -12,7 +12,7 @@ const descriptionMatches = (
   condition: ConditionDescriptionMatches,
   issue: IssueProps | PRProps,
 ) => {
-  const pattern = new RegExp(processRegExpPattern(condition.pattern));
+  const pattern = processRegExpPattern(condition.pattern);
   return pattern.test(issue.description);
 };
 

--- a/src/conditions/descriptionMatches.ts
+++ b/src/conditions/descriptionMatches.ts
@@ -1,4 +1,5 @@
 import { IssueProps, PRProps } from '.';
+import { processRegExpPattern } from '../utils';
 
 const TYPE = 'descriptionMatches';
 
@@ -11,7 +12,7 @@ const descriptionMatches = (
   condition: ConditionDescriptionMatches,
   issue: IssueProps | PRProps,
 ) => {
-  const pattern = new RegExp(condition.pattern);
+  const pattern = new RegExp(processRegExpPattern(condition.pattern));
   return pattern.test(issue.description);
 };
 

--- a/src/conditions/pr/branchMatches.ts
+++ b/src/conditions/pr/branchMatches.ts
@@ -9,7 +9,7 @@ export interface ConditionBranchMatches {
 }
 
 const branchMatches = (condition: ConditionBranchMatches, pr: PRProps) => {
-  const pattern = new RegExp(processRegExpPattern(condition.pattern));
+  const pattern = processRegExpPattern(condition.pattern);
   return pattern.test(pr.branch);
 };
 

--- a/src/conditions/pr/branchMatches.ts
+++ b/src/conditions/pr/branchMatches.ts
@@ -1,4 +1,5 @@
 import { PRProps } from '.';
+import { processRegExpPattern } from '../../utils';
 
 const TYPE = 'branchMatches';
 
@@ -8,7 +9,7 @@ export interface ConditionBranchMatches {
 }
 
 const branchMatches = (condition: ConditionBranchMatches, pr: PRProps) => {
-  const pattern = new RegExp(condition.pattern);
+  const pattern = new RegExp(processRegExpPattern(condition.pattern));
   return pattern.test(pr.branch);
 };
 

--- a/src/conditions/titleMatches.ts
+++ b/src/conditions/titleMatches.ts
@@ -12,7 +12,7 @@ const titleMatches = (
   condition: ConditionTitleMatches,
   issue: IssueProps | PRProps,
 ) => {
-  const pattern = new RegExp(processRegExpPattern(condition.pattern));
+  const pattern = processRegExpPattern(condition.pattern);
   return pattern.test(issue.title);
 };
 

--- a/src/conditions/titleMatches.ts
+++ b/src/conditions/titleMatches.ts
@@ -1,4 +1,5 @@
 import { IssueProps, PRProps } from '.';
+import { processRegExpPattern } from '../utils';
 
 const TYPE = 'titleMatches';
 
@@ -11,7 +12,7 @@ const titleMatches = (
   condition: ConditionTitleMatches,
   issue: IssueProps | PRProps,
 ) => {
-  const pattern = new RegExp(condition.pattern);
+  const pattern = new RegExp(processRegExpPattern(condition.pattern));
   return pattern.test(issue.title);
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,5 +15,5 @@ export const processRegExpPattern = (pattern: string) => {
 
   return flags
     ? RegExp.apply(RegExp, [source, flags])
-    : pattern;
+    : new RegExp(pattern);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,15 @@ export const formatColour = (colour: string) => {
     return colour;
   }
 };
+
+export const processRegExpPattern = (pattern: string) => {
+  const matchDelimiters = pattern.match(/^\/(.*)\/(.*)$/);
+
+  const regexp = (matchDelimiters || []).slice(1);
+  const flags = regexp.pop();
+  const source = regexp.join('');
+
+  return flags
+    ? RegExp.apply(RegExp, [source, flags])
+    : pattern;
+};


### PR DESCRIPTION
Hi @IvanFon thanks for great work on the super-labeler-action ! 🥇 

I have started to use it recently because it covers all of use case that I need to proper label issues and PRs.

However I was unable to pass flags/modifires to `titleMatches` pattern shorthand. If you know the way how to pass the pattern like this   `"pattern": "/^wip:/i"` (the goal here is to match case insensitive word and main issue is that in JSON it should be wrapped in double quotes) please let me know (also then this PR is unnecessary ;) ).  .

Like I mentioned above I was struggling with RegExp pattern to pass `/i` flag which make the check case insensitive. Checking the codebase I noticed that RegExp object takes only first parameter with pattern and second parameter with flags is omitted. See details with example below:

<details>

```jsx
const titleMatches = (
  condition: ConditionTitleMatches,
  issue: IssueProps | PRProps,
) => {
  const pattern = new RegExp(condition.pattern); //omited flag parameter
  return pattern.test(issue.title);
};
```

</details>

Also passing shorthand regexp as string in JSON is problematic( see [this thread](https://stackoverflow.com/questions/39154255/converting-regexp-to-string-then-back-to-regexp) on stackoverflow). I have used proposed solution and make PR to allow pass shorthand regexp including flags/modifirers.

With this PR you will be able to replace
```jsx
{
  "type": "titleMatches",
  "pattern": "^(wip|WIP):"
}
```

with this one

```jsx
{
  "type": "titleMatches",
  "pattern": "/^wip:/i"
}
```
Which seems to be not big beneficial in above case. However it can cover all possible option of capitalising the `wip` word if necessary. In my case I don't care about the letter capitalising in issue ticket - more important is to applied a label. I prefer to edit the title at some point that triaging and adding label


I think the alternate way might be also passing additional `flag` prop in matchers object. See details below

<details>

```jsx
export interface ConditionTitleMatches {
  type: typeof TYPE;
  pattern: string;
}
```
to

```jsx
export interface ConditionTitleMatches {
  type: typeof TYPE;
  pattern: string;
  flag: string;
}

const titleMatches = (
  condition: ConditionTitleMatches,
  issue: IssueProps | PRProps,
) => {
  const pattern = new RegExp(condition.pattern, condition.flag); //pass flag parameter
  return pattern.test(issue.title);
};
```

</details>


Please share your thoughts about this ! 