### PR TITLE
Refactor processRegExpPattern

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,4 +13,3 @@ export const processRegExpPattern = (pattern: string) => {
   
   return new RegExp(source || pattern, flags);
 };
-

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ export const formatColour = (colour: string) => {
 export const processRegExpPattern = (pattern: string) => {
   const matchDelimiters = pattern.match(/^\/(.*)\/(.*)$/);
 
-  const [source ,flags] = (matchDelimiters || []).slice(1);
+  const [,source ,flags] = matchDelimiters || [];
   
   return new RegExp(source || pattern, flags);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,11 +9,8 @@ export const formatColour = (colour: string) => {
 export const processRegExpPattern = (pattern: string) => {
   const matchDelimiters = pattern.match(/^\/(.*)\/(.*)$/);
 
-  const regexp = (matchDelimiters || []).slice(1);
-  const flags = regexp.pop();
-  const source = regexp.join('');
-
-  return flags
-    ? RegExp.apply(RegExp, [source, flags])
-    : new RegExp(pattern);
+  const [source ,flags] = (matchDelimiters || []).slice(1);
+  
+  return new RegExp(source || pattern, flags);
 };
+


### PR DESCRIPTION
During last work with the repo I have looked on `processRegexp(pattern)` function and... decide to refactor it. It should be more clear now. We can refactor it more by replacig below line 

``` jsx
const [source ,flags] = (matchDelimiters || []).slice(1);
```

to

``` jsx
const [,source ,flags] = matchDelimiters || [];
```

but I don't have strong opinion about this. What version do you like more ?