### PR TITLE
feat: improve labels fetch and create/update

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2762,12 +2762,8 @@ exports.formatColour = (colour) => {
 };
 exports.processRegExpPattern = (pattern) => {
     const matchDelimiters = pattern.match(/^\/(.*)\/(.*)$/);
-    const regexp = (matchDelimiters || []).slice(1);
-    const flags = regexp.pop();
-    const source = regexp.join('');
-    return flags
-        ? RegExp.apply(RegExp, [source, flags])
-        : new RegExp(pattern);
+    const [, source, flags] = matchDelimiters || [];
+    return new RegExp(source || pattern, flags);
 };
 
 
@@ -8907,7 +8903,12 @@ const syncLabels = ({ client, config, repo, }) => __awaiter(void 0, void 0, void
             if (label.description !== configLabel.description ||
                 label.color !== utils_1.formatColour(configLabel.color)) {
                 core.debug(`Recreate ${JSON.stringify(configLabel)} (prev: ${JSON.stringify(label)})`);
-                yield api_1.updateLabel({ client, repo, label: configLabel });
+                try {
+                    yield api_1.updateLabel({ client, repo, label: configLabel });
+                }
+                catch (e) {
+                    core.error(`Label update error: ${e.message}`);
+                }
             }
         }
         else {
@@ -8916,7 +8917,7 @@ const syncLabels = ({ client, config, repo, }) => __awaiter(void 0, void 0, void
                 yield api_1.createLabel({ client, repo, label: configLabel });
             }
             catch (e) {
-                core.error(e);
+                core.error(`Label create error: ${e.message}`);
             }
         }
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -26578,8 +26578,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getLabels = ({ client, repo, }) => __awaiter(void 0, void 0, void 0, function* () {
-    const labels = yield client.issues.listLabelsForRepo(Object.assign({}, repo));
-    return labels.data.map((label) => ({
+    const options = yield client.issues.listLabelsForRepo.endpoint.merge(Object.assign({}, repo));
+    const labels = yield client.paginate(options);
+    return labels.map((label) => ({
         name: label.name,
         description: label.description,
         color: label.color,

--- a/dist/index.js
+++ b/dist/index.js
@@ -2760,6 +2760,15 @@ exports.formatColour = (colour) => {
         return colour;
     }
 };
+exports.processRegExpPattern = (pattern) => {
+    const matchDelimiters = pattern.match(/^\/(.*)\/(.*)$/);
+    const regexp = (matchDelimiters || []).slice(1);
+    const flags = regexp.pop();
+    const source = regexp.join('');
+    return flags
+        ? RegExp.apply(RegExp, [source, flags])
+        : new RegExp(pattern);
+};
 
 
 /***/ }),
@@ -6558,14 +6567,15 @@ function escapeProperty(s) {
 /***/ }),
 
 /***/ 435:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'creatorMatches';
 const creatorMatches = (condition, issue) => {
-    const pattern = new RegExp(condition.pattern);
+    const pattern = utils_1.processRegExpPattern(condition.pattern);
     return pattern.test(issue.creator);
 };
 exports.default = [TYPE, creatorMatches];
@@ -8902,7 +8912,12 @@ const syncLabels = ({ client, config, repo, }) => __awaiter(void 0, void 0, void
         }
         else {
             core.debug(`Create ${JSON.stringify(configLabel)}`);
-            yield api_1.createLabel({ client, repo, label: configLabel });
+            try {
+                yield api_1.createLabel({ client, repo, label: configLabel });
+            }
+            catch (e) {
+                core.error(e);
+            }
         }
     }
 });
@@ -9873,14 +9888,15 @@ module.exports = require("events");
 /***/ }),
 
 /***/ 618:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'branchMatches';
 const branchMatches = (condition, pr) => {
-    const pattern = new RegExp(condition.pattern);
+    const pattern = utils_1.processRegExpPattern(condition.pattern);
     return pattern.test(pr.branch);
 };
 exports.default = [TYPE, branchMatches];
@@ -10024,14 +10040,15 @@ if (process.platform === 'linux') {
 /***/ }),
 
 /***/ 658:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'descriptionMatches';
 const descriptionMatches = (condition, issue) => {
-    const pattern = new RegExp(condition.pattern);
+    const pattern = utils_1.processRegExpPattern(condition.pattern);
     return pattern.test(issue.description);
 };
 exports.default = [TYPE, descriptionMatches];
@@ -10116,14 +10133,15 @@ module.exports = function btoa(str) {
 /***/ }),
 
 /***/ 686:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'titleMatches';
 const titleMatches = (condition, issue) => {
-    const pattern = new RegExp(condition.pattern);
+    const pattern = utils_1.processRegExpPattern(condition.pattern);
     return pattern.test(issue.title);
 };
 exports.default = [TYPE, titleMatches];

--- a/src/api/getLabels.ts
+++ b/src/api/getLabels.ts
@@ -5,8 +5,11 @@ export const getLabels = async ({
   client,
   repo,
 }: ApiProps): Promise<Labels> => {
-  const labels = await client.issues.listLabelsForRepo({ ...repo });
-  return labels.data.map((label) => ({
+  const options = await client.issues.listLabelsForRepo.endpoint.merge({ ...repo });
+  
+  const labels = await client.paginate(options)
+  
+  return labels.map((label) => ({
     name: label.name,
     description: label.description,
     color: label.color,

--- a/src/syncLabels.ts
+++ b/src/syncLabels.ts
@@ -35,7 +35,12 @@ const syncLabels = async ({
             label,
           )})`,
         );
-        await updateLabel({ client, repo, label: configLabel });
+        try {
+          await updateLabel({ client, repo, label: configLabel });
+        }
+        catch(e) {
+          core.error(`Label update error: ${e.message}`)
+        }
       }
     } else {
       core.debug(`Create ${JSON.stringify(configLabel)}`);
@@ -43,7 +48,7 @@ const syncLabels = async ({
         await createLabel({ client, repo, label: configLabel });
       }
       catch (e) {
-        core.error(e)
+        core.error(`Label create error: ${e.message}`)
       }
     }
   }

--- a/src/syncLabels.ts
+++ b/src/syncLabels.ts
@@ -39,7 +39,12 @@ const syncLabels = async ({
       }
     } else {
       core.debug(`Create ${JSON.stringify(configLabel)}`);
-      await createLabel({ client, repo, label: configLabel });
+      try {
+        await createLabel({ client, repo, label: configLabel });
+      }
+      catch (e) {
+        core.error(e)
+      }
     }
   }
 };


### PR DESCRIPTION
I have a repository with `50` labels and I found out that current API fetch return only `30` labels.
- [x] I implemented paginated fetch according to GitHub docs 
- [x] and added catching errors during labels create and update.