### PR TITLE
feat: skip labeling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,33 +140,35 @@ The config object contains three keys:
 - `labels`: Your repository's labels, which will be automatically created and updated by Super Labeler
 - `issue`: Labels to apply to issues, and their conditions
 - `pr`: Labels to apply to pull requests, and their conditions
+- `skip_labeling`: Label name that indicates, that labeling should not be performed. Content is a key of `labels` options
 
 Take a look at the examples in this file to get a feel for how to configure it. The below Typescript interface, which is used by this action, may also be helpful:
 
 <details>
   <summary><b>Click to show Typescript config interface</b></summary>
 
-```js
+```ts
 interface Config {
   labels: {
     [key: string]: {
-      name: string,
-      colour: string,
-      description: string,
-    },
+      name: string;
+      colour: string;
+      description: string;
+    };
   };
   issue: {
     [key: string]: {
-      requires: number,
-      conditions: IssueCondition[],
-    },
+      requires: number;
+      conditions: IssueCondition[];
+    };
   };
   pr: {
     [key: string]: {
-      requires: number,
-      conditions: PRCondition[],
-    },
+      requires: number;
+      conditions: PRCondition[];
+    };
   };
+  skip_labeling: string;
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export interface Config {
       conditions: PRCondition[];
     };
   };
+  skip_labeling: string;
 }
 
 const context = github.context;
@@ -101,6 +102,7 @@ const context = github.context;
       await applyPRLabels({
         client,
         config: config.pr,
+        skipLabeling: config.skip_labeling,
         labelIdToName,
         prContext: curContext.context,
         repo,
@@ -109,6 +111,7 @@ const context = github.context;
       await applyIssueLabels({
         client,
         config: config.issue,
+        skipLabeling: config.skip_labeling,
         issueContext: curContext.context,
         labelIdToName,
         repo,


### PR DESCRIPTION
There was no issue with that option, but I think it would be useful.

## Motivation

Currently, there is no possibility to disable auto labeling for particular issues or PR. Sometimes users will want to manually add some label, independently of issue/pr content. Action will remove that label because the content would not satisfy conditions. 

To not "fight" with the bot, it would be useful to have the possibility to skip labeling

## Detials

I added `skip_labeling` option to config. If the issue or PR has assigned a label that is pointed by this option, labeling will be skipped.
