### PR TITLE
Feat: allow local run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,9 @@ typings/
 .tern-port
 
 web/dist/
+
+# local config file
+/labels.local.json
+/event*.json
+
+!examples/

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Super Labeler'
 description: 'A superpowered issue and pull request labeler for Github Actions.'
 author: 'IvanFon'
 inputs:
-  github-token:
+  GITHUB_TOKEN:
     description: 'The GITHUB_TOKEN secret'
     required: true
   config:

--- a/bin/copyLocalRun.js
+++ b/bin/copyLocalRun.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+
+const { o: overwrite } = require('minimist')(process.argv.slice(2));
+
+const srcPath = 'examples'
+const dstPath = ''
+
+const fileToCopy = [
+  '.env.example',
+  'event.issue.example.json',
+  'event.pr.example.json',
+  'labels.local.example.json',
+]
+
+const rename = filename => filename.replace('.example','')
+
+let skippedFiles = 0
+console.log('\n');
+
+fileToCopy.forEach( fileName => {
+  const dstFile = `${dstPath}${rename(fileName)}`
+  if (fs.existsSync(dstFile) && !overwrite) {
+    console.log(dstFile, ` - exists coping skipped !`)
+    skippedFiles ++;
+  } else {
+    fs.copyFileSync(`${srcPath}/${fileName}`, dstFile) 
+  }
+});
+
+if (skippedFiles >0) {
+  console.log('\n','Use -o flag to copy with overwrite','\n')
+} else {
+  console.log('Copied', fileToCopy.length , "files", '\n')
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -2760,6 +2760,12 @@ exports.formatColour = (colour) => {
         return colour;
     }
 };
+exports.processRegExpPattern = (pattern) => {
+    const matchDelimiters = pattern.match(/^\/(.*)\/(.*)$/);
+    const [, source, flags] = matchDelimiters || [];
+    return new RegExp(source || pattern, flags);
+};
+exports.normalize = (text) => (text || '').toUpperCase();
 
 
 /***/ }),
@@ -6558,14 +6564,15 @@ function escapeProperty(s) {
 /***/ }),
 
 /***/ 435:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'creatorMatches';
 const creatorMatches = (condition, issue) => {
-    const pattern = new RegExp(condition.pattern);
+    const pattern = utils_1.processRegExpPattern(condition.pattern);
     return pattern.test(issue.creator);
 };
 exports.default = [TYPE, creatorMatches];
@@ -9873,14 +9880,15 @@ module.exports = require("events");
 /***/ }),
 
 /***/ 618:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'branchMatches';
 const branchMatches = (condition, pr) => {
-    const pattern = new RegExp(condition.pattern);
+    const pattern = utils_1.processRegExpPattern(condition.pattern);
     return pattern.test(pr.branch);
 };
 exports.default = [TYPE, branchMatches];
@@ -10024,14 +10032,15 @@ if (process.platform === 'linux') {
 /***/ }),
 
 /***/ 658:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'descriptionMatches';
 const descriptionMatches = (condition, issue) => {
-    const pattern = new RegExp(condition.pattern);
+    const pattern = utils_1.processRegExpPattern(condition.pattern);
     return pattern.test(issue.description);
 };
 exports.default = [TYPE, descriptionMatches];
@@ -10116,14 +10125,15 @@ module.exports = function btoa(str) {
 /***/ }),
 
 /***/ 686:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'titleMatches';
 const titleMatches = (condition, issue) => {
-    const pattern = new RegExp(condition.pattern);
+    const pattern = utils_1.processRegExpPattern(condition.pattern);
     return pattern.test(issue.title);
 };
 exports.default = [TYPE, titleMatches];
@@ -10239,14 +10249,21 @@ module.exports = (promise, onFinally) => {
 /***/ }),
 
 /***/ 708:
-/***/ (function(__unusedmodule, exports) {
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = __webpack_require__(163);
 const TYPE = 'isOpen';
+var States;
+(function (States) {
+    States["Open"] = "OPEN";
+    States["Closed"] = "CLOSED";
+})(States || (States = {}));
 const isOpen = (condition, issue) => {
-    return condition.value ? issue.state === 'open' : issue.state === 'closed';
+    return (utils_1.normalize(issue.state) ===
+        utils_1.normalize(condition.value ? States.Open : States.Closed));
 };
 exports.default = [TYPE, isOpen];
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,0 +1,15 @@
+# Example of env config to test action locally
+# To generate a token, see https://github.com/settings/tokens
+
+# Required
+export INPUT_GITHUB_TOKEN=your-personal-token
+export GITHUB_REPOSITORY=owner/repo-name
+
+# Optional
+export INPUT_CONFIG=labels.local.json
+
+# Debugging
+export SHOW_LOGS=false
+
+# Comment to disable dry run
+export GH_ACTION_LOCAL_TEST=true

--- a/examples/event.issue.example.json
+++ b/examples/event.issue.example.json
@@ -1,0 +1,10 @@
+{
+  "issue": {
+    "number": 7,
+    "user": {
+      "login": "GitHub Login"
+    },
+    "title": "example issue title",
+    "state": "OPEN"
+  }
+}

--- a/examples/event.pr.example.json
+++ b/examples/event.pr.example.json
@@ -1,0 +1,15 @@
+{
+  "pull_request": {
+    "head": {
+      "ref": "example branch name"
+    },
+    "base": {
+      "ref": "example base branch name"
+    },
+    "number": 18,
+    "user": {
+      "login": "GitHub Login"
+    },
+    "title": "Example pr title"
+  }
+}

--- a/examples/labels.local.example.json
+++ b/examples/labels.local.example.json
@@ -1,0 +1,139 @@
+{
+  "labels": {
+    "wip": {
+      "name": "WIP",
+      "colour": "#ffffaa",
+      "description": "Work in progress"
+    },
+    "bug": {
+      "name": "bug",
+      "colour": "#d73a4a",
+      "description": "Something isn't working"
+    },
+    "fix": {
+      "name": "bugfix",
+      "colour": "#e825aa",
+      "description": "PR with bugfix"
+    },
+    "feat": {
+      "name": "enhancement",
+      "colour": "#a2eeef",
+      "description": "New feature or request"
+    },
+    "refactor": {
+      "name": "refactor",
+      "colour": "#42d1c5",
+      "description": "Changes existing feature"
+    },
+    "chore": {
+      "name": "chore",
+      "colour": "#ffd4cc",
+      "description": "Package updates etc"
+    },
+    "docs": {
+      "name": "documentation",
+      "colour": "#23c4ff",
+      "description": "Improvements or additions to documentation"
+    },
+    "tests": {
+      "name": "tests",
+      "colour": "#23c4ff",
+      "description": "All related to testing"
+    },
+    "perf": {
+      "name": "performance",
+      "colour": "#23c4ff",
+      "description": "Performance related changes"
+    },
+    "ci": {
+      "name": "CI",
+      "colour": "#23c4ff",
+      "description": "Continous Integration related changes"
+    },
+    "buil": {
+      "name": "build",
+      "colour": "#23c4ff",
+      "description": "Affects build process changes"
+    },
+    "revert": {
+      "name": "revert",
+      "colour": "#23c4ff",
+      "description": "Reverts previous changes"
+    },
+    "mobile": {
+      "name": "Mobile",
+      "colour": "#23c4ff",
+      "description": "Mobile"
+    },
+    "ios": {
+      "name": "iOS",
+      "colour": "#23c4ff",
+      "description": "iOS"
+    },
+    "android": {
+      "name": "Android",
+      "colour": "#23c4ff",
+      "description": "Android"
+    },
+    "web": {
+      "name": "Web",
+      "colour": "#23c4ff",
+      "description": "Web"
+    },
+    "desktop": {
+      "name": "Desktop",
+      "colour": "#23c4ff",
+      "description": "Desktop"
+    },
+    "api": {
+      "name": "API",
+      "colour": "#23c4ff",
+      "description": "API"
+    },
+    "automation": {
+      "name": "automation",
+      "colour": "#23c4ff",
+      "description": "automation"
+    }
+  },
+  "issue": {
+    "bug": {
+      "requires": 2,
+      "conditions": [
+        {
+          "type": "titleMatches",
+          "pattern": "/^(bug|\\[bug)/i"
+        },
+        {
+          "type": "isOpen",
+          "value": true
+        }
+      ]
+    },
+    "wip": {
+      "requires": 2,
+      "conditions": [
+        {
+          "type": "titleMatches",
+          "pattern": "/^(wip|\\[wip)/i"
+        },
+        {
+          "type": "isOpen",
+          "value": true
+        }
+      ]
+    }
+  },
+  "pr": {
+    "wip": {
+      "requires": 1,
+      "conditions": [
+        {
+          "type": "titleMatches",
+          "pattern": "/^(wip|\\[wip)/i"
+        }
+      ]
+    }
+  
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   },
   "scripts": {
     "build": "ncc build src/index.ts -o dist",
-    "format": "prettier --write src/**/*.ts"
+    "format": "prettier --write src/**/*.ts",
+    "dev:pr": "EVENT_PATH=event.pr.json yarn dev:run",
+    "dev:issue": "EVENT_PATH=event.issue.json yarn dev:run",
+    "dev:run": "source .env && GITHUB_EVENT_PATH=${EVENT_PATH} node dist/index.js",
+    "dev:init": "node bin/copyLocalRun.js"
   },
   "prettier": {
     "arrowParens": "always",
@@ -21,7 +25,8 @@
   "dependencies": {
     "@actions/core": "^1.2.3",
     "@actions/github": "^2.1.1",
-    "minimatch": "^3.0.4"
+    "minimatch": "^3.0.4",
+    "minimist": "^1.2.5"
   },
   "devDependencies": {
     "@types/minimatch": "^3.0.3",

--- a/src/api/addLabel.ts
+++ b/src/api/addLabel.ts
@@ -5,10 +5,12 @@ export const addLabel = async ({
   repo,
   num,
   label,
+  dryRun,
 }: IssueApiProps & {
   label: string;
+  dryRun: boolean;
 }) =>
-  await client.issues.addLabels({
+  !dryRun && await client.issues.addLabels({
     ...repo,
     issue_number: num,
     labels: [label],

--- a/src/api/createLabel.ts
+++ b/src/api/createLabel.ts
@@ -6,9 +6,11 @@ export const createLabel = async ({
   client,
   repo,
   label,
-}: ApiProps & { label: Label }) => {
+  dryRun,
+}: ApiProps & { label: Label, dryRun: boolean }) => {
+  
   const color = formatColour(label.color);
-  await client.issues.createLabel({
+  !dryRun && await client.issues.createLabel({
     ...repo,
     ...label,
     color,

--- a/src/api/deleteLabel.ts
+++ b/src/api/deleteLabel.ts
@@ -4,8 +4,9 @@ export const deleteLabel = async ({
   client,
   repo,
   name,
-}: ApiProps & { name: string }) => {
-  await client.issues.deleteLabel({
+  dryRun
+}: ApiProps & { name: string, dryRun: boolean }) => {
+  !dryRun && await client.issues.deleteLabel({
     ...repo,
     name,
   });

--- a/src/api/removeLabel.ts
+++ b/src/api/removeLabel.ts
@@ -5,10 +5,12 @@ export const removeLabel = async ({
   repo,
   num,
   label,
+  dryRun,
 }: IssueApiProps & {
   label: string;
+  dryRun: boolean;
 }) =>
-  await client.issues.removeLabel({
+  !dryRun && await client.issues.removeLabel({
     ...repo,
     issue_number: num,
     name: label,

--- a/src/api/updateLabel.ts
+++ b/src/api/updateLabel.ts
@@ -6,9 +6,10 @@ export const updateLabel = async ({
   client,
   repo,
   label,
-}: ApiProps & { label: Label }) => {
+  dryRun,
+}: ApiProps & { label: Label, dryRun: boolean }) => {
   const color = formatColour(label.color);
-  await client.issues.updateLabel({
+  !dryRun && await client.issues.updateLabel({
     ...repo,
     current_name: label.name,
     description: label.description,

--- a/src/conditions/isOpen.ts
+++ b/src/conditions/isOpen.ts
@@ -1,10 +1,11 @@
 import { IssueProps, PRProps } from '.';
+import { normalize } from '../utils';
 
 const TYPE = 'isOpen';
 
-const STATES = {
-  open: "OPEN",
-  closed: "CLOSED"
+enum States {
+  Open = 'OPEN',
+  Closed = 'CLOSED',
 }
 
 export interface ConditionIsOpen {
@@ -12,10 +13,11 @@ export interface ConditionIsOpen {
   value: boolean;
 }
 
-const normalize = (text: string ) => (text || '').toUpperCase();
-
 const isOpen = (condition: ConditionIsOpen, issue: IssueProps | PRProps) => {
-  return normalize(issue.state) === normalize(condition.value ?  STATES.open : STATES.closed);
+  return (
+    normalize(issue.state) ===
+    normalize(condition.value ? States.Open : States.Closed)
+  );
 };
 
 export default [TYPE, isOpen] as const;

--- a/src/conditions/isOpen.ts
+++ b/src/conditions/isOpen.ts
@@ -2,13 +2,20 @@ import { IssueProps, PRProps } from '.';
 
 const TYPE = 'isOpen';
 
+const STATES = {
+  open: "OPEN",
+  closed: "CLOSED"
+}
+
 export interface ConditionIsOpen {
   type: typeof TYPE;
   value: boolean;
 }
 
+const normalize = (text: string ) => (text || '').toUpperCase();
+
 const isOpen = (condition: ConditionIsOpen, issue: IssueProps | PRProps) => {
-  return condition.value ? issue.state === 'open' : issue.state === 'closed';
+  return normalize(issue.state) === normalize(condition.value ?  STATES.open : STATES.closed);
 };
 
 export default [TYPE, isOpen] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,121 +1,30 @@
-import fs from 'fs';
-import path from 'path';
+const github = require('@actions/github');
+const core = require('@actions/core');
+const path = require('path');
 
-import * as core from '@actions/core';
-import * as github from '@actions/github';
+const superLabeler = require('./superLabeler');
 
-import { applyIssueLabels, applyPRLabels } from './applyLabels';
-import { IssueCondition, PRCondition } from './conditions';
-import {
-  IssueContext,
-  parseIssueContext,
-  parsePRContext,
-  PRContext,
-} from './parseContext';
-import syncLabels from './syncLabels';
+const { GITHUB_WORKSPACE = '', SHOW_LOGS, GH_ACTION_LOCAL_TEST } = process.env;
 
-export interface Config {
-  labels: {
-    [key: string]: {
-      name: string;
-      colour: string;
-      description: string;
-    };
-  };
-  issue: {
-    [key: string]: {
-      requires: number;
-      conditions: IssueCondition[];
-    };
-  };
-  pr: {
-    [key: string]: {
-      requires: number;
-      conditions: PRCondition[];
-    };
-  };
-}
+const dryRun = !!GH_ACTION_LOCAL_TEST;
+const showLogs = SHOW_LOGS === 'true';
+const configFile = core.getInput('config');
 
-const context = github.context;
+const configPath = path.join(
+  GITHUB_WORKSPACE,
+  configFile,
+);
 
-(async () => {
-  try {
-    // Get inputs
-    const token = core.getInput('github-token', { required: true });
-    const configPath = path.join(
-      process.env.GITHUB_WORKSPACE as string,
-      core.getInput('config'),
-    );
-    const repo = context.repo;
+const GITHUB_TOKEN = core.getInput('GITHUB_TOKEN', {
+  required: true,
+});
 
-    const client = new github.GitHub(token);
+const options = {
+  configPath,
+  showLogs,
+  dryRun,
+};
 
-    // Load config
-    if (!fs.existsSync(configPath)) {
-      throw new Error(`config not found at "${configPath}"`);
-    }
-    const config: Config = JSON.parse(fs.readFileSync(configPath).toString());
-    core.debug(`Config: ${JSON.stringify(config)}`);
+const action = new superLabeler(new github.GitHub(GITHUB_TOKEN), options);
 
-    let curContext:
-      | { type: 'pr'; context: PRContext }
-      | { type: 'issue'; context: IssueContext };
-    if (context.payload.pull_request) {
-      const ctx = await parsePRContext(context, client, repo);
-      if (!ctx) {
-        throw new Error('pull request not found on context');
-      }
-      core.debug(`PR context: ${JSON.stringify(ctx)}`);
-
-      curContext = {
-        type: 'pr',
-        context: ctx,
-      };
-    } else if (context.payload.issue) {
-      const ctx = parseIssueContext(context);
-      if (!ctx) {
-        throw new Error('issue not found on context');
-      }
-      core.debug(`issue context: ${JSON.stringify(ctx)}`);
-
-      curContext = {
-        type: 'issue',
-        context: ctx,
-      };
-    } else {
-      return;
-    }
-
-    await syncLabels({ client, repo, config: config.labels });
-
-    // Mapping of label ids to Github names
-    const labelIdToName = Object.entries(config.labels).reduce(
-      (acc: { [key: string]: string }, cur) => {
-        acc[cur[0]] = cur[1].name;
-        return acc;
-      },
-      {},
-    );
-
-    if (curContext.type === 'pr') {
-      await applyPRLabels({
-        client,
-        config: config.pr,
-        labelIdToName,
-        prContext: curContext.context,
-        repo,
-      });
-    } else if (curContext.type === 'issue') {
-      await applyIssueLabels({
-        client,
-        config: config.issue,
-        issueContext: curContext.context,
-        labelIdToName,
-        repo,
-      });
-    }
-  } catch (err) {
-    core.error(err.message);
-    core.setFailed(err.message);
-  }
-})();
+action.run();

--- a/src/superLabeler.ts
+++ b/src/superLabeler.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+import { GitHub } from '@actions/github';
+
+import { applyIssueLabels, applyPRLabels } from './applyLabels';
+import { Config, Options } from './types';
+import {
+  IssueContext,
+  parseIssueContext,
+  parsePRContext,
+  PRContext,
+} from './parseContext';
+import syncLabels from './syncLabels';
+
+const context = github.context;
+
+class ActionSuperLabeler {
+  client: GitHub;
+  opts: Options;
+
+  constructor(client: any, options: any) {
+    this.client = client;
+    this.opts = options;
+  }
+
+  _log(message:string) {
+    if (!this.opts.showLogs) return;
+    console.log(message);
+  }
+
+async run () {
+  try {
+    const configPath = this.opts.configPath;
+    const dryRun = this.opts.dryRun;
+    const repo = context.repo;
+
+    // Load config
+    if (!fs.existsSync(configPath)) {
+      throw new Error(`config not found at "${configPath}"`);
+    }
+    const config: Config = JSON.parse(fs.readFileSync(configPath).toString());
+    core.debug(`Config: ${JSON.stringify(config)}`);
+
+    let curContext:
+      | { type: 'pr'; context: PRContext }
+      | { type: 'issue'; context: IssueContext };
+    if (context.payload.pull_request) {
+      const ctx = await parsePRContext(context, this.client, repo);
+      if (!ctx) {
+        throw new Error('pull request not found on context');
+      }
+      core.debug(`PR context: ${JSON.stringify(ctx)}`);
+
+      curContext = {
+        type: 'pr',
+        context: ctx,
+      };
+    } else if (context.payload.issue) {
+      const ctx = parseIssueContext(context);
+      if (!ctx) {
+        throw new Error('issue not found on context');
+      }
+      core.debug(`issue context: ${JSON.stringify(ctx)}`);
+
+      curContext = {
+        type: 'issue',
+        context: ctx,
+      };
+    } else {
+      return;
+    }
+
+    await syncLabels({ client: this.client, repo, config: config.labels, dryRun });
+
+    // Mapping of label ids to Github names
+    const labelIdToName = Object.entries(config.labels).reduce(
+      (acc: { [key: string]: string }, cur) => {
+        acc[cur[0]] = cur[1].name;
+        return acc;
+      },
+      {},
+    );
+
+    if (curContext.type === 'pr') {
+      await applyPRLabels({
+        client: this.client,
+        config: config.pr,
+        labelIdToName,
+        prContext: curContext.context,
+        repo,
+        dryRun,
+      });
+    } else if (curContext.type === 'issue') {
+      await applyIssueLabels({
+        client: this.client,
+        config: config.issue,
+        issueContext: curContext.context,
+        labelIdToName,
+        repo,
+        dryRun,
+      });
+    }
+  } catch (err) {
+    core.error(err.message);
+    core.setFailed(err.message);
+  }
+}};
+
+module.exports = ActionSuperLabeler;

--- a/src/syncLabels.ts
+++ b/src/syncLabels.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import { GitHub } from '@actions/github';
 
-import { Config } from '.';
+import { Config } from './types';
 import { createLabel, getLabels, Repo, updateLabel } from './api';
 import { formatColour } from './utils';
 
@@ -9,10 +9,12 @@ const syncLabels = async ({
   client,
   config,
   repo,
+  dryRun,
 }: {
   client: GitHub;
   config: Config['labels'];
   repo: Repo;
+  dryRun: boolean;
 }) => {
   const curLabels = await getLabels({ client, repo });
   core.debug(`curLabels: ${JSON.stringify(curLabels)}`);
@@ -35,11 +37,11 @@ const syncLabels = async ({
             label,
           )})`,
         );
-        await updateLabel({ client, repo, label: configLabel });
+        await updateLabel({ client, repo, label: configLabel, dryRun });
       }
     } else {
       core.debug(`Create ${JSON.stringify(configLabel)}`);
-      await createLabel({ client, repo, label: configLabel });
+      await createLabel({ client, repo, label: configLabel, dryRun });
     }
   }
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,29 @@
+import { IssueCondition, PRCondition } from './conditions';
+
+export interface Config {
+  labels: {
+    [key: string]: {
+      name: string;
+      colour: string;
+      description: string;
+    };
+  };
+  issue: {
+    [key: string]: {
+      requires: number;
+      conditions: IssueCondition[];
+    };
+  };
+  pr: {
+    [key: string]: {
+      requires: number;
+      conditions: PRCondition[];
+    };
+  };
+}
+
+export interface Options {
+  configPath: string;
+  showLogs: boolean;
+  dryRun: boolean;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,5 @@ export const processRegExpPattern = (pattern: string) => {
 
   return new RegExp(source || pattern, flags);
 };
+
+export const normalize = (text: string ) => (text || '').toUpperCase();

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,11 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"


### PR DESCRIPTION
closes #10 

I have provide some refactor that allow to run action locally. Do not modify README.md yet however the steps to run locally are as follow:

1. use `yarn dev:init` to copy example .env file and configs from `example` folder ( pass `-o` if you want to override already existing files in root directory having the same name )
2. go to `.env` and pass your github token (see the comment inside env on how to get it) as well as test repo name and owner in below pattern 

```
owner/repo-name
```

3. keep `GH_ACTION_LOCAL_TEST=true` to not proceed any action on mentioned repo. Comment this line to allow modification of result on repo

4. configure `event.pr.json` and `event.issue.json` to mock issue / pr payload
5.  run `yarn dev:issue` to simulate action on issue 
6.  run `yarn dev:pr` to simulate action on pr 

**CHANGES**
- I have export some types definition to `types.t.ds` (need to move main function from index.ts file)
- move main function to `superLabeler.ts' and call it from `index.ts`
- do initial configuration in `index.ts`
- pass `dryRun` prop to disable proceed action on repo (e.g when applying labels after match)
- add some example config in `examples` folder
- add `copyLocalRun.js` script to allow copy examples configs in quick way

**BREAKING_CHANGES:**
I have noticed that there was a problem to pass token from local `.env` when its name was 'github-token' in `action.yml`. After I have change it to `GITHUB_TOKEN` it start to work



**CONCLUSION**
Let me know what you think ( probably naming etc is not 100% accurate) however lets focus on the approach first.

With above setup we can mock events and see results without pushing the code to repo and manually modifying the issue/pr in test repo. I'm also working with extend logging system and will target this PR when finish
