### PR TITLE
chore: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # super-labeler-action
 
-**This action already has the features and stability for the original use case I wrote it for, and I'm not looking to add to it at this time. If you're looking for additional features, there's an active fork at [videndum/super-labeler-action](https://github.com/videndum/super-labeler-action).**
+**This action already has the features and stability for the original use case I wrote it for, and I'm not looking to add to it at this time. If you're looking for additional features, there's an active fork at [resnovas/smartcloud](https://github.com/resnovas/smartcloud).** Please see issue #26 for more information.
 
 A superpowered issue and pull request labeler for Github Actions.
 


### PR DESCRIPTION
Update the readme to be correct for the current status of the project. The old Videndum project is now Public Achieve and "Smartcloud" has taken it's place.